### PR TITLE
Add tag-based post retrieval and clean up imports in JSONServer

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -13,6 +13,7 @@ from views.post import (
 from views.user import (
     create_user,
     login_user,
+    update_user
 )
 
 # Add your imports below this line
@@ -114,6 +115,12 @@ class JSONServer(HandleRequests):
                     response_body = update_post(request_body)
                 return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
+        elif url["requested_resource"] == "users":
+            if pk != 0:
+                response_body = update_user(request_body)
+                return self.response(
+                    response_body, status.HTTP_200_SUCCESS.value
+                )
 
         return self.response(
             "Requested resource not found",

--- a/json-server.py
+++ b/json-server.py
@@ -5,10 +5,12 @@ from nss_handler import HandleRequests, status
 from views.post import (
     create_post,
     get_user_posts,
-    get_post_details,
     update_post,
     get_all_posts,
-    get_post_by_id
+    get_post_by_id,
+    get_posts_by_tag_id,
+    get_unapproved_posts,
+    approve_post
 )
 
 from views.user import (
@@ -19,7 +21,6 @@ from views.user import (
 )
 
 # Add your imports below this line
-from views import get_unapproved_posts, approve_post
 from views import get_all_categories, create_category, get_category_by_id
 from views import get_tags, get_tag_by_id, create_tag
 
@@ -60,6 +61,11 @@ class JSONServer(HandleRequests):
                 if not approved:
                     response_body = get_unapproved_posts()
                     return self.response(response_body, status.HTTP_200_SUCCESS.value)
+
+            if "tag_id" in query_params:
+                tag_id = query_params['tag_id'][0]
+                response_body = get_posts_by_tag_id(tag_id)
+                return self.response(response_body, status.HTTP_200_SUCCESS.value)
             response_body = get_all_posts()
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
         

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,4 +1,4 @@
-from .user import create_user, login_user, get_user, list_users
+from .user import create_user, login_user, get_user, list_users, update_user
 from .post import create_post, get_user_posts, get_post_by_id, update_post, get_all_posts, get_unapproved_posts, approve_post
 from .category import get_all_categories, get_category_by_id, create_category
 from .tag import get_tag_by_id, get_tags, create_tag

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,4 +1,4 @@
 from .user import create_user, login_user, get_user, list_users
-from .post import create_post, get_user_posts, get_post_by_id, update_post, get_all_posts, get_unapproved_posts, approve_post
+from .post import create_post, get_user_posts, get_post_by_id, update_post, get_all_posts, get_unapproved_posts, approve_post, get_posts_by_tag_id, get_post_details
 from .category import get_all_categories, get_category_by_id, create_category
 from .tag import get_tag_by_id, get_tags, create_tag

--- a/views/category.py
+++ b/views/category.py
@@ -9,6 +9,7 @@ def get_all_categories():
         db_cursor.execute(
             """
             SELECT * FROM Categories
+            ORDER BY label
             """,
         )
 

--- a/views/post.py
+++ b/views/post.py
@@ -1,6 +1,9 @@
 import sqlite3
 import json
 from datetime import datetime
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parent.parent / "db.sqlite3"
 
 def _fetch_related_data_for_posts(db_cursor, post_ids):
     """Helper function to fetch tags, comments, and reactions for given post IDs
@@ -118,125 +121,6 @@ def _attach_related_data(posts, tags_by_post, comments_by_post, reactions_by_pos
         post["reactions"] = reactions_by_post.get(post["id"], [])
 
     return posts
-
-
-def _fetch_related_data_for_posts(db_cursor, post_ids):
-    """Helper function to fetch tags, comments, and reactions for given post IDs
-
-    Args:
-        db_cursor: SQLite cursor
-        post_ids: List of post IDs to fetch data for
-
-    Returns:
-        tuple: (tags_by_post, comments_by_post, reactions_by_post) dictionaries
-    """
-    if not post_ids:
-        return {}, {}, {}
-
-    placeholders = ",".join("?" * len(post_ids))
-
-    # Fetch tags
-    db_cursor.execute(
-        f"""
-        SELECT pt.post_id, t.id, t.label
-        FROM PostTags pt
-        JOIN Tags t ON pt.tag_id = t.id
-        WHERE pt.post_id IN ({placeholders})
-    """,
-        post_ids,
-    )
-
-    tags_by_post = {}
-    for row in db_cursor.fetchall():
-        tags_by_post.setdefault(row["post_id"], []).append(
-            {"id": row["id"], "label": row["label"]}
-        )
-
-    # Fetch comments
-    db_cursor.execute(
-        f"""
-        SELECT 
-            cm.post_id, cm.id, cm.content,
-            json_object(
-                'id', u.id, 'first_name', u.first_name,
-                'last_name', u.last_name, 'username', u.username
-            ) as author
-        FROM Comments cm
-        JOIN Users u ON cm.author_id = u.id
-        WHERE cm.post_id IN ({placeholders})
-    """,
-        post_ids,
-    )
-
-    comments_by_post = {}
-    for row in db_cursor.fetchall():
-        comments_by_post.setdefault(row["post_id"], []).append(
-            {
-                "id": row["id"],
-                "content": row["content"],
-                "author": json.loads(row["author"]),
-            }
-        )
-
-    # Fetch reactions
-    db_cursor.execute(
-        f"""
-        SELECT 
-            pr.post_id, pr.id,
-            json_object(
-                'id', u.id, 'first_name', u.first_name,
-                'last_name', u.last_name, 'username', u.username
-            ) as user,
-            json_object(
-                'id', r.id, 'label', r.label, 'image_url', r.image_url
-            ) as reaction
-        FROM PostReactions pr
-        JOIN Users u ON pr.user_id = u.id
-        JOIN Reactions r ON pr.reaction_id = r.id
-        WHERE pr.post_id IN ({placeholders})
-    """,
-        post_ids,
-    )
-
-    reactions_by_post = {}
-    for row in db_cursor.fetchall():
-        reactions_by_post.setdefault(row["post_id"], []).append(
-            {
-                "id": row["id"],
-                "user": json.loads(row["user"]),
-                "reaction": json.loads(row["reaction"]),
-            }
-        )
-
-    return tags_by_post, comments_by_post, reactions_by_post
-
-
-def _attach_related_data(posts, tags_by_post, comments_by_post, reactions_by_post):
-    """Helper to attach related data to post objects
-
-    Args:
-        posts: List of post dictionaries
-        tags_by_post: Dictionary mapping post_id to tags
-        comments_by_post: Dictionary mapping post_id to comments
-        reactions_by_post: Dictionary mapping post_id to reactions
-
-    Returns:
-        list: Posts with related data attached
-    """
-    for post in posts:
-        # Parse JSON fields
-        if isinstance(post.get("user"), str):
-            post["user"] = json.loads(post["user"])
-        if isinstance(post.get("category"), str):
-            post["category"] = json.loads(post["category"])
-
-        # Attach related arrays
-        post["tags"] = tags_by_post.get(post["id"], [])
-        post["comments"] = comments_by_post.get(post["id"], [])
-        post["reactions"] = reactions_by_post.get(post["id"], [])
-
-    return posts
-
 
 def create_post(post):
     """Adds post to the database
@@ -285,7 +169,6 @@ def create_post(post):
 
         return json.dumps(new_post)
 
-
 def get_all_posts():
     """Get all approved posts with full related data
 
@@ -323,7 +206,6 @@ def get_all_posts():
         posts = _attach_related_data(posts, tags, comments, reactions)
 
         return json.dumps(posts)
-
 
 def get_user_posts(user_id):
     """Retrieves a user's posts from the database with full related data
@@ -365,7 +247,6 @@ def get_user_posts(user_id):
         posts = _attach_related_data(posts, tags, comments, reactions)
 
         return json.dumps(posts)
-
 
 def get_post_by_id(post_id):
     """Get a single post with full related data
@@ -410,7 +291,6 @@ def get_post_by_id(post_id):
 
         return json.dumps(posts[0])
 
-
 def get_post_details(post_id):
     """Reader detail: approved + published in the past, plus author display name."""
     with sqlite3.connect("./db.sqlite3") as conn:
@@ -450,7 +330,6 @@ def get_post_details(post_id):
                 "author_display_name": row["author_display_name"],
             }
         )
-
 
 def update_post(post):
     with sqlite3.connect("./db.sqlite3") as conn:

--- a/views/post.py
+++ b/views/post.py
@@ -194,7 +194,7 @@ def get_all_posts():
             WHERE p.approved = 1
               AND date(p.publication_date) <= date('now')
             ORDER BY date(p.publication_date) DESC
-        """
+            """
         )
 
         posts = [dict(row) for row in db_cursor.fetchall()]
@@ -365,7 +365,6 @@ def update_post(post):
         
         return get_post_by_id(post["id"])
 
-
 def get_unapproved_posts():
     with sqlite3.connect("./db.sqlite3") as conn:
         conn.row_factory = sqlite3.Row
@@ -462,3 +461,38 @@ def update_post_tags(post_id, tag_ids, db_cursor=None):
             conn.row_factory = sqlite3.Row
             cursor = conn.cursor()
             _update_tags(cursor)
+
+def get_posts_by_tag_id(tag_id):
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+            SELECT
+                p.id, p.title, p.content, p.approved,
+                p.publication_date, p.image_url,
+                json_object(
+                    'id', u.id, 'first_name', u.first_name,
+                    'last_name', u.last_name, 'username', u.username
+                ) as user,
+                json_object('id', c.id, 'label', c.label) as category
+            FROM Posts p
+            JOIN Users u ON p.user_id = u.id
+            JOIN Categories c ON p.category_id = c.id
+            JOIN PostTags pt ON pt.post_id = p.id
+            WHERE p.approved = 1
+              AND date(p.publication_date) <= date('now')
+              AND pt.tag_id = ?
+            ORDER BY date(p.publication_date) DESC
+            """, (tag_id,)
+        )
+
+        posts = [dict(row) for row in db_cursor.fetchall()]
+        post_ids = [p["id"] for p in posts]
+
+        # Fetch and attach related data
+        tags, comments, reactions = _fetch_related_data_for_posts(db_cursor, post_ids)
+        posts = _attach_related_data(posts, tags, comments, reactions)
+
+        return json.dumps(posts)

--- a/views/user.py
+++ b/views/user.py
@@ -72,10 +72,8 @@ def create_user(user):
 
         id = db_cursor.lastrowid
 
-        return json.dumps({
-            'token': id,
-            'valid': True
-        })
+        return json.dumps({"token": id, "valid": True})
+
 
 def list_users():
     """Returns a list of all users from the database
@@ -83,11 +81,12 @@ def list_users():
     Returns:
         json string: A list of all users
     """
-    with sqlite3.connect('./db.sqlite3') as conn:
+    with sqlite3.connect("./db.sqlite3") as conn:
         conn.row_factory = sqlite3.Row
         db_cursor = conn.cursor()
 
-        db_cursor.execute("""
+        db_cursor.execute(
+            """
         select
             u.id,
             u.first_name,
@@ -101,43 +100,49 @@ def list_users():
             u.type,
             u.profile_image_url
         from Users u
-        """)
+        """
+        )
 
         users = []
         dataset = db_cursor.fetchall()
 
         for row in dataset:
             user = {
-                'id': row['id'],
-                'first_name': row['first_name'],
-                'last_name': row['last_name'],
-                'username': row['username'],
-                'email': row['email'],
-                'password': row['password'],
-                'bio': row['bio'],
-                'created_on': row['created_on'],
-                'active': row['active'],
-                'type': row['type'],
-                'is_staff': True if row['type'] == 'admin' else False,
-                'profile_image_url': row['profile_image_url']
+                "id": row["id"],
+                "first_name": row["first_name"],
+                "last_name": row["last_name"],
+                "username": row["username"],
+                "email": row["email"],
+                "password": row["password"],
+                "bio": row["bio"],
+                "created_on": row["created_on"],
+                "active": row["active"],
+                "type": row["type"],
+                "is_staff": True if row["type"] == "admin" else False,
+                "profile_image_url": row["profile_image_url"],
             }
             users.append(user)
 
         return json.dumps(users)
-    
+
+
 def get_user(userId):
     with sqlite3.connect("./db.sqlite3") as conn:
         conn.row_factory = sqlite3.Row
         db_cursor = conn.cursor()
 
-        db_cursor.execute("""
+        db_cursor.execute(
+            """
         SELECT * FROM Users u
         WHERE u.id = ?
-        """, (userId,),)
+        """,
+            (userId,),
+        )
 
         user = db_cursor.fetchone()
 
         return json.dumps(dict(user))
+
 
 def update_user(user):
     with sqlite3.connect(DB_PATH) as conn:
@@ -158,25 +163,27 @@ def update_user(user):
                 active = ?,
                 type = ?
             WHERE id = ?
-            """, (
-                user['first_name'],
-                user['last_name'],
-                user['email'],
-                user['bio'],
-                user['username'],
-                user['password'],
-                user['profile_image_url'],
-                user['active'],
-                user['type'],
-                user['id']
-                )
+            """,
+            (
+                user["first_name"],
+                user["last_name"],
+                user["email"],
+                user["bio"],
+                user["username"],
+                user["password"],
+                user["profile_image_url"],
+                user["active"],
+                user["type"],
+                user["id"],
+            ),
         )
 
         db_cursor.execute(
             """
             SELECT * FROM Users
             WHERE id = ?
-            """, (user["id"],)
+            """,
+            (user["id"],),
         )
 
         updated_user = db_cursor.fetchone()

--- a/views/user.py
+++ b/views/user.py
@@ -98,7 +98,8 @@ def list_users():
             u.bio,
             u.created_on,
             u.active,
-            u.type
+            u.type,
+            u.profile_image_url
         from Users u
         """)
 
@@ -117,7 +118,8 @@ def list_users():
                 'created_on': row['created_on'],
                 'active': row['active'],
                 'type': row['type'],
-                'is_staff': True if row['type'] == 'admin' else False
+                'is_staff': True if row['type'] == 'admin' else False,
+                'profile_image_url': row['profile_image_url']
             }
             users.append(user)
 
@@ -137,3 +139,46 @@ def get_user(userId):
 
         return json.dumps(dict(user))
 
+def update_user(user):
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+            UPDATE Users
+            SET
+                first_name = ?,
+                last_name = ?,
+                email = ?,
+                bio = ?,
+                username = ?,
+                password = ?,
+                profile_image_url = ?,
+                active = ?,
+                type = ?
+            WHERE id = ?
+            """, (
+                user['first_name'],
+                user['last_name'],
+                user['email'],
+                user['bio'],
+                user['username'],
+                user['password'],
+                user['profile_image_url'],
+                user['active'],
+                user['type'],
+                user['id']
+                )
+        )
+
+        db_cursor.execute(
+            """
+            SELECT * FROM Users
+            WHERE id = ?
+            """, (user["id"],)
+        )
+
+        updated_user = db_cursor.fetchone()
+
+        return json.dumps(dict(updated_user))

--- a/views/user.py
+++ b/views/user.py
@@ -23,7 +23,7 @@ def login_user(user):
 
         db_cursor.execute(
             """
-            select id, username
+            select id, username, active
             from Users
             where username = ?
             and password = ?
@@ -33,7 +33,7 @@ def login_user(user):
 
         user_from_db = db_cursor.fetchone()
 
-        if user_from_db is not None:
+        if user_from_db is not None and user_from_db["active"]:
             response = {"valid": True, "token": user_from_db["id"]}
         else:
             response = {"valid": False}
@@ -73,7 +73,6 @@ def create_user(user):
         id = db_cursor.lastrowid
 
         return json.dumps({"token": id, "valid": True})
-
 
 def list_users():
     """Returns a list of all users from the database
@@ -124,7 +123,6 @@ def list_users():
             users.append(user)
 
         return json.dumps(users)
-
 
 def get_user(userId):
     with sqlite3.connect("./db.sqlite3") as conn:


### PR DESCRIPTION
This pull request adds the ability to filter posts by tag and improves the organization of post-related view imports. The main change is the addition of a new endpoint to fetch posts by a specific tag, along with the necessary backend function. There are also some minor import cleanups.

### New functionality

* Added a new function `get_posts_by_tag_id` in `views/post.py` to fetch approved posts by a given tag, including related user, category, tags, comments, and reactions data.
* Updated the `do_GET` method in `json-server.py` to handle the `tag_id` query parameter and return posts filtered by tag using the new function.

### Code organization and imports

* Added `get_posts_by_tag_id` and `get_post_details` to the `views/__init__.py` exports for easier importing elsewhere in the codebase.
* Cleaned up imports in `json-server.py` by removing redundant direct imports of `get_unapproved_posts` and `approve_post` from `views`.
* Updated the grouped import from `views.post` in `json-server.py` to include `get_posts_by_tag_id`, `get_unapproved_posts`, and `approve_post`.