### PR TITLE
Add functionality to retrieve posts by category ID

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -25,7 +25,8 @@ from views.post import (
     search_posts_by_title,
     delete_post,
     get_subscribed_posts,
-    get_post_header_image
+    get_post_header_image,
+    get_posts_by_category_id
 )
 
 from views.user import (
@@ -129,6 +130,11 @@ class JSONServer(HandleRequests):
                 response_body = get_posts_by_tag_id(tag_id)
                 return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
+            if "category_id" in query_params:
+                category_id = query_params["category_id"][0]
+                response_body = get_posts_by_category_id(category_id)
+                return self.response(response_body, status.HTTP_200_SUCCESS.value)
+            
             if "title" in query_params:
                 search_term = query_params["title"][0]
                 response_body = search_posts_by_title(search_term)

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -24,6 +24,8 @@ from .post import (
     get_subscribed_posts,
     search_posts_by_title,
     get_post_header_image,
+    get_posts_by_category_id,
+    get_post_title
 )
 
 from .tag import (

--- a/views/post.py
+++ b/views/post.py
@@ -630,3 +630,41 @@ def get_post_header_image(post_id):
         db_cursor.execute("SELECT image FROM Posts WHERE id = ?", (post_id,))
         result = db_cursor.fetchone()
         return result[0] if result and result[0] else None
+
+
+def get_posts_by_category_id(category_id):
+    """Return all posts with the given category"""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+            SELECT
+                p.id, p.title, p.content, p.approved,
+                p.publication_date, p.updated_at,
+                json_object(
+                    'id', u.id, 'first_name', u.first_name,
+                    'last_name', u.last_name, 'username', u.username
+                ) as user,
+                json_object('id', c.id, 'label', c.label) as category
+            FROM Posts p
+            JOIN Users u ON p.user_id = u.id
+            JOIN Categories c ON p.category_id = c.id
+            WHERE p.approved = 1
+              AND date(p.publication_date) <= date('now')
+              AND c.id = ?
+            ORDER BY date(p.publication_date) DESC
+
+            """,
+            (category_id,),
+        )
+
+        posts = [dict(row) for row in db_cursor.fetchall()]
+        post_ids = [p["id"] for p in posts]
+
+        # Fetch and attach related data
+        tags, comments, reactions = _fetch_related_data_for_posts(db_cursor, post_ids)
+        posts = _attach_related_data(posts, tags, comments, reactions)
+
+        return json.dumps(posts)


### PR DESCRIPTION
This pull request adds support for retrieving posts by category, allowing clients to filter posts using a category ID. The main changes are the addition of the new `get_posts_by_category_id` function and the integration of this functionality into the server's request handling.

**New feature: Retrieve posts by category**

* Added a new function `get_posts_by_category_id` in `views/post.py` to fetch and return all posts associated with a given category, including related user, category, tags, comments, and reactions data.
* Updated the server's GET handler in `json-server.py` to support the `category_id` query parameter, enabling clients to filter posts by category through the API.

**Code integration and imports**

* Imported `get_posts_by_category_id` in `json-server.py` and `views/__init__.py` to make the new function available for routing and external use. [[1]](diffhunk://#diff-a29ecc6ae38d9710455c6f44e5d73950e7f4c0c199968ceb77107288b6438e6cL28-R29) [[2]](diffhunk://#diff-759953537c740a554246832a29c0c5091b77eae0d45ab15cf5db6063394bd13aR27-R28)