### PR TITLE
Enhance post approval functionality to accept boolean value and updat…

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -284,9 +284,16 @@ class JSONServer(HandleRequests):
                 request_body = {}
 
         if url["requested_resource"] == "posts" and pk != 0:
-            # special admin approve route: PUT /posts/<id> with body {"approved": true}
+            # special admin approval route: PUT /posts/<id> with body {"approved": true|false}
             if "approved" in request_body and len(request_body) == 1:
-                response_body = approve_post(pk)
+                approved_value = request_body["approved"]
+                if not isinstance(approved_value, bool):
+                    return self.response(
+                        json.dumps({"error": "'approved' must be a boolean"}),
+                        status.HTTP_400_CLIENT_ERROR_BAD_REQUEST_DATA.value,
+                    )
+
+                response_body = approve_post(pk, approved_value)
                 return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
             response_body = update_post(request_body)

--- a/views/post.py
+++ b/views/post.py
@@ -460,14 +460,15 @@ def get_unapproved_posts():
         return json.dumps(posts)
 
 
-def approve_post(post_id):
-    """Approves the specified post"""
+def approve_post(post_id, approved=True):
+    """Sets the approval status of the specified post"""
     with sqlite3.connect(DB_PATH) as conn:
         conn.row_factory = sqlite3.Row
         db_cursor = conn.cursor()
         db_cursor.execute(
-            "UPDATE POSTS SET approved = 1, updated_at = ? WHERE id = ?",
+            "UPDATE POSTS SET approved = ?, updated_at = ? WHERE id = ?",
             (
+                1 if approved else 0,
                 datetime.now(),
                 post_id,
             ),
@@ -478,12 +479,12 @@ def approve_post(post_id):
         if row is None:
             return json.dumps({})
 
-        approved_post = dict(row)
+        approved_post = get_post_by_id(post_id, db_cursor)
 
         if "image" in approved_post:
             del approved_post["image"]
 
-        return json.dumps(approved_post)
+        return approved_post
 
 
 def get_posts_by_tag_id(tag_id):


### PR DESCRIPTION
This pull request updates the post approval logic to allow both approving and unapproving posts via the admin route, and improves type safety and return values in related functions. The main changes include updating the approval route to accept both `true` and `false`, modifying the database update logic to support unapproval, and improving the return value of the `approve_post` function.

**Admin approval route improvements:**

* The admin approval route (`PUT /posts/<id>`) now accepts both `{"approved": true}` and `{"approved": false}` in the request body, allowing admins to both approve and unapprove posts. The route also now checks that the `approved` field is a boolean and returns an error if not.

**Database and function updates:**

* The `approve_post` function now takes an `approved` parameter (defaulting to `True`), and updates the database with the correct approval status (1 or 0) based on the value provided.
* The `approve_post` function now returns a post dictionary (excluding the `image` field) instead of a JSON string, improving consistency and type safety.…e database accordingly