### PR TITLE
16 & 17 Edit and Delete Categories (Admin)

### DIFF
--- a/database.json
+++ b/database.json
@@ -1,0 +1,19 @@
+{
+  "posts": [
+    {
+      "id": 1,
+      "title": "json-server",
+      "author": "typicode"
+    }
+  ],
+  "comments": [
+    {
+      "id": 1,
+      "body": "some comment",
+      "postId": 1
+    }
+  ],
+  "profile": {
+    "name": "typicode"
+  }
+}

--- a/json-server.py
+++ b/json-server.py
@@ -9,7 +9,7 @@ from views.comment import (
     get_comments_by_post_id,
     update_comment,
     get_comment_by_id,
-    delete_comment
+    delete_comment,
 )
 
 from views.post import (
@@ -26,7 +26,7 @@ from views.post import (
     add_reaction,
     get_subscribed_posts,
     get_post_header_image,
-    get_posts_by_category_id
+    get_posts_by_category_id,
 )
 
 from views.user import (
@@ -39,7 +39,13 @@ from views.user import (
     delete_subscription,
     add_subscription,
 )
-from views.category import get_all_categories, create_category, get_category_by_id
+from views.category import (
+    get_all_categories,
+    create_category,
+    get_category_by_id,
+    update_category,
+    delete_category,
+)
 from views.tag import get_tags, get_tag_by_id, create_tag
 
 
@@ -134,7 +140,7 @@ class JSONServer(HandleRequests):
                 category_id = query_params["category_id"][0]
                 response_body = get_posts_by_category_id(category_id)
                 return self.response(response_body, status.HTTP_200_SUCCESS.value)
-            
+
             if "title" in query_params:
                 search_term = query_params["title"][0]
                 response_body = search_posts_by_title(search_term)
@@ -214,7 +220,13 @@ class JSONServer(HandleRequests):
                         url["pk"], query_params["sub_id"][0]
                     )
                     return self.response(response_body, status.HTTP_200_SUCCESS.value)
-        if url["requested_resource"] == "comments" and url['pk'] != 0:
+
+        if url["requested_resource"] == "categories" and url["pk"] != 0:
+            successfully_deleted = delete_category(url["pk"])
+            if successfully_deleted:
+                return self.response("", status.HTTP_204_SUCCESS_NO_RESPONSE_BODY.value)
+
+        if url["requested_resource"] == "comments" and url["pk"] != 0:
             response_body = delete_comment(url["pk"])
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
         return self.response(
@@ -319,6 +331,10 @@ class JSONServer(HandleRequests):
 
         if url["requested_resource"] == "comments" and pk != 0:
             response_body = update_comment(pk, request_body)
+            return self.response(response_body, status.HTTP_200_SUCCESS.value)
+
+        if url["requested_resource"] == "categories" and pk != 0:
+            response_body = update_category(pk, request_body)
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
         return self.response(

--- a/loaddata.sql
+++ b/loaddata.sql
@@ -301,7 +301,7 @@ VALUES (5, 7, "2025-02-23")
   WHERE follower_id = 5 AND author_id = 5
 
   DELETE FROM Subscriptions
-  WHERE id IS NOT NULL
+  WHERE id IS NOT NULL;
 
   ALTER TABLE Users
   DROP COLUMN profile_image_url;
@@ -312,17 +312,17 @@ VALUES (5, 7, "2025-02-23")
 
   UPDATE DemotionQueue
   SET approver_one_id = 4
-  WHERE approver_one_id = 16
+  WHERE approver_one_id = 16;
 
   DELETE FROM DemotionQueue
-  WHERE action = 'cancel demotion'
+  WHERE action = 'cancel demotion';
 
 
   UPDATE Posts
   SET category_id = 1
-  WHERE category_id = 'undefined'
+  WHERE category_id = 'undefined';
 
   DELETE FROM PostTags
-  WHERE id > 58
+  WHERE id > 58;
 
   UPDATE sqlite_sequence SET seq=58 WHERE name = 'PostTags'

--- a/reset_db.sql
+++ b/reset_db.sql
@@ -367,3 +367,7 @@ UPDATE Posts
 SET updated_at = publication_date
 
 WHERE updated_at IS NULL
+
+UPDATE Users
+SET type = 'admin'
+WHERE id = 16

--- a/views/category.py
+++ b/views/category.py
@@ -78,6 +78,34 @@ def create_category(category):
         return json.dumps(dict(category)) if category else json.dumps({})
 
 
+def update_category(category_id, category):
+    """Updates the category with the provided id"""
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+            UPDATE Categories
+            SET label = ?
+            WHERE id = ?
+            """,
+            (category["label"], category_id),
+        )
+
+        db_cursor.execute(
+            """
+            SELECT * FROM Categories
+            WHERE id = ?
+            """,
+            (category_id,),
+        )
+
+        category = db_cursor.fetchone()
+
+        return json.dumps(dict(category)) if category else json.dumps({})
+
+
 def delete_category(category_id):
     """Deletes the category with the provided id"""
     with sqlite3.connect(DB_PATH) as conn:
@@ -92,4 +120,9 @@ def delete_category(category_id):
             (category_id,),
         )
 
-        return json.dumps({"deleted": True})
+        deleted_count = db_cursor.rowcount
+
+        if deleted_count == 0:
+            return False
+
+        return True


### PR DESCRIPTION
TLDR; Added Edit and Delete Buttons and Function for Admin Accounts using tokens.

This pull request introduces support for updating and deleting categories through the API, along with some database and code cleanup. The main changes involve adding new endpoints and logic for category management, as well as improving SQL statement correctness.

**Category management enhancements:**

* Added `update_category` and improved `delete_category` functions in `views/category.py`, enabling categories to be updated and deleted via the API, returning appropriate responses based on operation success. [[1]](diffhunk://#diff-4679a793f02fb1a9ac5103e92da85d511020dd47c117702dd0fd99f35149a206R81-R108) [[2]](diffhunk://#diff-4679a793f02fb1a9ac5103e92da85d511020dd47c117702dd0fd99f35149a206L95-R128)
* Updated `json-server.py` to route PUT and DELETE requests for categories to the new `update_category` and improved `delete_category` functions, including proper import statements for these functions. [[1]](diffhunk://#diff-a29ecc6ae38d9710455c6f44e5d73950e7f4c0c199968ceb77107288b6438e6cL42-R48) [[2]](diffhunk://#diff-a29ecc6ae38d9710455c6f44e5d73950e7f4c0c199968ceb77107288b6438e6cL217-R229) [[3]](diffhunk://#diff-a29ecc6ae38d9710455c6f44e5d73950e7f4c0c199968ceb77107288b6438e6cR336-R339)

**Database and code cleanup:**

* Fixed missing semicolons in SQL statements in `loaddata.sql` to ensure proper execution of multiple queries. [[1]](diffhunk://#diff-e76f51df176407e73f61be716b8f5bc090b7ba87e961c654b7bc5fe36cf68377L304-R304) [[2]](diffhunk://#diff-e76f51df176407e73f61be716b8f5bc090b7ba87e961c654b7bc5fe36cf68377L315-R326)
* Added an SQL statement in `reset_db.sql` to set the user type to 'admin' for user with id 16.

**Other updates:**

* Added a sample `database.json` file, likely for testing or documentation purposes.