### PR TITLE
API tickets 18 and 19 edit and delete tags

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -50,7 +50,13 @@ from views.category import (
     update_category,
     delete_category,
 )
-from views.tag import get_tags, get_tag_by_id, create_tag
+from views.tag import (
+    get_tags,
+    get_tag_by_id,
+    create_tag,
+    update_tag,
+    delete_tag,
+)
 
 from views.reaction import create_reaction, update_reaction, delete_reaction
 
@@ -246,9 +252,21 @@ class JSONServer(HandleRequests):
         if url["requested_resource"] == "comments" and url["pk"] != 0:
             response_body = delete_comment(url["pk"])
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
+
+        if url["requested_resource"] == "tags" and url["pk"] != 0:
+            successfully_deleted = delete_tag(url["pk"])
+            if successfully_deleted:
+                return self.response("", status.HTTP_204_SUCCESS_NO_RESPONSE_BODY.value)
+
+            return self.response(
+                "Requested resource not found",
+                status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value,
+            )
+
         if url["requested_resource"] == "post_reaction" and url["pk"] != 0:
             response_body = remove_reaction(url["pk"])
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
+
         if url["requested_resource"] == "reactions" and url["pk"] != 0:
             response_body = delete_reaction(url["pk"])
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
@@ -403,6 +421,10 @@ class JSONServer(HandleRequests):
 
         if url["requested_resource"] == "categories" and pk != 0:
             response_body = update_category(pk, request_body)
+            return self.response(response_body, status.HTTP_200_SUCCESS.value)
+
+        if url["requested_resource"] == "tags" and pk != 0:
+            response_body = update_tag(pk, request_body)
             return self.response(response_body, status.HTTP_200_SUCCESS.value)
 
         if url["requested_resource"] == "reactions" and pk != 0:

--- a/views/tag.py
+++ b/views/tag.py
@@ -75,3 +75,45 @@ def create_tag(tag):
         new_tag = db_cursor.fetchone()
 
         return json.dumps(dict(new_tag)) if new_tag else json.dumps({})
+
+
+def update_tag(tag_id, tag):
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+            UPDATE Tags
+            SET label = ?
+            WHERE id = ?
+        """,
+            (tag["label"], tag_id),
+        )
+
+        db_cursor.execute(
+            """
+            SELECT id, label
+            FROM Tags
+            WHERE id = ?
+        """,
+            (tag_id,),
+        )
+
+        row = db_cursor.fetchone()
+        return json.dumps(dict(row)) if row else json.dumps({})
+
+
+def delete_tag(tag_id):
+    with sqlite3.connect(DB_PATH) as conn:
+        db_cursor = conn.cursor()
+
+        db_cursor.execute(
+            """
+            DELETE FROM Tags
+            WHERE id = ?
+        """,
+            (tag_id,),
+        )
+
+        return db_cursor.rowcount > 0


### PR DESCRIPTION
This pull request adds full support for updating and deleting tags in the API. The main changes include implementing new `update_tag` and `delete_tag` functions, exposing them through the HTTP server, and updating the import statements accordingly.

**Tag management enhancements:**

* Added `update_tag` and `delete_tag` functions to `views/tag.py` to allow updating and deleting tag records in the database. (`views/tag.py`)
* Updated the import in `json-server.py` to include `update_tag` and `delete_tag`.

**API endpoint updates:**

* Implemented support for HTTP PUT requests to `/tags/:id` to update a tag using the new `update_tag` function. (`json-server.py`)
* Implemented support for HTTP DELETE requests to `/tags/:id` to delete a tag using the new `delete_tag` function, returning appropriate HTTP status codes based on the outcome. (`json-server.py`)